### PR TITLE
style(robot): reduce size on desktop screens

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/xeroc/projects/chainsquad/chaoscraft/node_modules

--- a/src/robotDance.css
+++ b/src/robotDance.css
@@ -131,3 +131,11 @@
   max-width: 100%;
   height: auto;
 }
+
+/* Desktop screens - reduce robot size */
+@media (min-width: 1024px) {
+  .dancing-robot {
+    max-width: 200px;
+    width: 200px;
+  }
+}

--- a/src/robotSvg.ts
+++ b/src/robotSvg.ts
@@ -95,6 +95,19 @@ export function createDancingRobot(): SVGElement {
         .robot-eye {
           animation: robot-eye-glow 1s ease-in-out infinite;
         }
+        
+        .dancing-robot {
+          display: inline-block;
+          max-width: 100%;
+          height: auto;
+        }
+        
+        @media (min-width: 1024px) {
+          .dancing-robot {
+            max-width: 200px;
+            width: 200px;
+          }
+        }
       </style>
     </defs>
     


### PR DESCRIPTION
Add media query for desktop viewports (min-width: 1024px) to display
the dancing robot at a smaller 200px width. The robot remains visible
and proportional at the new size while being less intrusive on larger
screens.

Changes:
- Added desktop media query to src/robotDance.css
- Updated inline styles in src/robotSvg.ts for consistency

