### PR TITLE
feat(main): integrate countries section component

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,9 @@
             <!-- Random Joke Container -->
             <div id="joke-container-wrapper" class="flex justify-center items-center"></div>
             
+            <!-- Countries Section Container -->
+            <div id="countries-wrapper" class="flex justify-center items-center"></div>
+            
             <section class="mt-8 sm:mt-12 md:mt-16 mb-8 sm:mb-12 md:mb-16 w-full sm:max-w-2xl md:max-w-3xl lg:max-w-4xl xl:max-w-5xl mx-auto px-4 sm:px-6 md:px-8 py-8 sm:py-10 md:py-12 bg-gradient-to-br from-slate-900/40 via-slate-800/30 to-slate-900/40 rounded-2xl sm:rounded-3xl backdrop-blur-sm border border-white/10 shadow-xl hover:shadow-2xl transition-shadow duration-300 relative">
                 <!-- Decorative gradient accent line at top -->
                 <div class="absolute top-0 left-1/2 -translate-x-1/2 w-16 sm:w-20 md:w-24 h-1 bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-500 rounded-full"></div>

--- a/src/countriesComponent.test.ts
+++ b/src/countriesComponent.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for Countries Component
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createCountries, mountCountries, unmountCountries, getCountries, DEFAULT_COUNTRIES_CONFIG } from './countriesComponent';
+
+describe('CountriesComponent', () => {
+  beforeEach(() => {
+    // Clean up any existing elements
+    document.body.innerHTML = '';
+  });
+
+  describe('createCountries', () => {
+    it('should create a countries section element', () => {
+      const section = createCountries();
+      
+      expect(section).toBeInstanceOf(HTMLElement);
+      expect(section.id).toBe('countries-container');
+      expect(section.tagName).toBe('SECTION');
+    });
+
+    it('should have correct styling classes', () => {
+      const section = createCountries();
+      
+      expect(section.className).toContain('mt-6');
+      expect(section.className).toContain('max-w-4xl');
+      expect(section.className).toContain('mx-auto');
+      expect(section.className).toContain('bg-gradient-to-br');
+    });
+
+    it('should render default title', () => {
+      const section = createCountries();
+      const header = section.querySelector('h3');
+      
+      expect(header).not.toBeNull();
+      expect(header?.textContent).toBe(DEFAULT_COUNTRIES_CONFIG.title);
+    });
+
+    it('should render custom title', () => {
+      const customTitle = 'Custom Countries Title';
+      const section = createCountries({ title: customTitle });
+      const header = section.querySelector('h3');
+      
+      expect(header?.textContent).toBe(customTitle);
+    });
+
+    it('should render default countries list', () => {
+      const section = createCountries();
+      const badges = section.querySelectorAll('span');
+      
+      expect(badges.length).toBe(DEFAULT_COUNTRIES_CONFIG.countries.length);
+    });
+
+    it('should render custom countries list', () => {
+      const customCountries = ['Country A', 'Country B', 'Country C'];
+      const section = createCountries({ countries: customCountries });
+      const badges = section.querySelectorAll('span');
+      
+      expect(badges.length).toBe(3);
+      expect(badges[0].textContent).toBe('Country A');
+      expect(badges[1].textContent).toBe('Country B');
+      expect(badges[2].textContent).toBe('Country C');
+    });
+
+    it('should apply badge styling to countries', () => {
+      const section = createCountries();
+      const firstBadge = section.querySelector('span');
+      
+      expect(firstBadge?.className).toContain('px-3');
+      expect(firstBadge?.className).toContain('rounded-full');
+      expect(firstBadge?.className).toContain('bg-white/10');
+    });
+
+    it('should create flex container for countries', () => {
+      const section = createCountries();
+      const listContainer = section.querySelector('div');
+      
+      expect(listContainer?.className).toContain('flex');
+      expect(listContainer?.className).toContain('flex-wrap');
+      expect(listContainer?.className).toContain('justify-center');
+    });
+  });
+
+  describe('mountCountries', () => {
+    it('should mount to specified container', () => {
+      const container = document.createElement('div');
+      container.id = 'test-container';
+      document.body.appendChild(container);
+      
+      mountCountries('test-container');
+      
+      const mounted = document.getElementById('countries-container');
+      expect(mounted).not.toBeNull();
+      expect(container.contains(mounted)).toBe(true);
+    });
+
+    it('should use default container id when not specified', () => {
+      const container = document.createElement('div');
+      container.id = 'countries-wrapper';
+      document.body.appendChild(container);
+      
+      mountCountries();
+      
+      const mounted = document.getElementById('countries-container');
+      expect(mounted).not.toBeNull();
+      expect(container.contains(mounted)).toBe(true);
+    });
+
+    it('should log error if container not found', () => {
+      const consoleSpy = vi.spyOn(console, 'error');
+      
+      mountCountries('non-existent-container');
+      
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Container with ID "non-existent-container" not found')
+      );
+      
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('unmountCountries', () => {
+    it('should remove countries section from DOM', () => {
+      const container = document.createElement('div');
+      container.id = 'test-container';
+      document.body.appendChild(container);
+      
+      mountCountries('test-container');
+      expect(document.getElementById('countries-container')).not.toBeNull();
+      
+      unmountCountries();
+      expect(document.getElementById('countries-container')).toBeNull();
+    });
+
+    it('should handle case when section does not exist', () => {
+      // Should not throw
+      expect(() => unmountCountries()).not.toThrow();
+    });
+  });
+
+  describe('getCountries', () => {
+    it('should return null when not mounted', () => {
+      expect(getCountries()).toBeNull();
+    });
+
+    it('should return element when mounted', () => {
+      const container = document.createElement('div');
+      container.id = 'test-container';
+      document.body.appendChild(container);
+      
+      mountCountries('test-container');
+      const element = getCountries();
+      
+      expect(element).not.toBeNull();
+      expect(element?.id).toBe('countries-container');
+    });
+  });
+});

--- a/src/countriesComponent.ts
+++ b/src/countriesComponent.ts
@@ -1,0 +1,93 @@
+/**
+ * Countries Component
+ *
+ * Displays a section listing participating countries at the bottom of the page.
+ */
+
+export interface CountriesConfig {
+  title?: string;
+  countries?: string[];
+}
+
+export const DEFAULT_COUNTRIES_CONFIG: Required<CountriesConfig> = {
+  title: '🌍 Participating Countries',
+  countries: [
+    'United States',
+    'Germany',
+    'United Kingdom',
+    'Canada',
+    'Australia',
+    'Japan',
+    'France',
+    'Brazil',
+    'India',
+    'Netherlands'
+  ]
+};
+
+/**
+ * Creates a responsive countries section element
+ */
+export function createCountries(config: Partial<CountriesConfig> = {}): HTMLElement {
+  const finalConfig = { ...DEFAULT_COUNTRIES_CONFIG, ...config };
+  
+  // Create container
+  const container = document.createElement('section');
+  container.id = 'countries-container';
+  container.className = 'mt-6 sm:mt-8 md:mt-8 w-full max-w-4xl mx-auto px-4 sm:px-6 md:px-8 py-6 sm:py-8 md:py-8 bg-gradient-to-br from-slate-900/40 via-slate-800/30 to-slate-900/40 rounded-2xl backdrop-blur-sm border border-white/10 shadow-xl';
+  
+  // Header
+  const header = document.createElement('h3');
+  header.className = 'text-lg sm:text-xl md:text-2xl font-bold text-white mb-4 sm:mb-6 text-center';
+  header.textContent = finalConfig.title;
+  
+  // Countries list
+  const listContainer = document.createElement('div');
+  listContainer.className = 'flex flex-wrap justify-center gap-2 sm:gap-3 md:gap-4';
+  
+  finalConfig.countries.forEach(country => {
+    const badge = document.createElement('span');
+    badge.className = 'px-3 sm:px-4 py-1.5 sm:py-2 bg-white/10 hover:bg-white/20 text-gray-200 rounded-full text-xs sm:text-sm md:text-base border border-white/20 transition-all duration-200 cursor-default';
+    badge.textContent = country;
+    listContainer.appendChild(badge);
+  });
+  
+  container.appendChild(header);
+  container.appendChild(listContainer);
+  
+  return container;
+}
+
+/**
+ * Mounts the countries section to the specified container
+ * @param containerId - The ID of the container element to mount the countries section into
+ */
+export function mountCountries(containerId: string = 'countries-wrapper'): void {
+  const container = document.getElementById(containerId);
+  
+  if (!container) {
+    console.error(`Container with ID "${containerId}" not found`);
+    return;
+  }
+  
+  const countriesSection = createCountries();
+  container.appendChild(countriesSection);
+}
+
+/**
+ * Unmounts the countries component from the DOM
+ */
+export function unmountCountries(): void {
+  const countriesContainer = document.getElementById('countries-container');
+  if (countriesContainer) {
+    countriesContainer.remove();
+  }
+}
+
+/**
+ * Gets the current countries container element
+ * @returns HTMLElement | null The countries container element or null
+ */
+export function getCountries(): HTMLElement | null {
+  return document.getElementById('countries-container');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { mountBanner } from './bannerComponent';
 import { mountNavbar } from './navbarComponent';
 import { mountFooter } from './footerComponent';
 import { mountJoke } from './jokeComponent';
+import { mountCountries } from './countriesComponent';
 import { injectResponsiveUtilities } from './responsiveUtils';
 
 // Initialize when DOM is ready
@@ -31,6 +32,9 @@ if (typeof document !== 'undefined') {
     // Mount random joke below robot
     mountJoke('joke-container-wrapper');
     
+    // Mount countries section (after joke, before footer)
+    mountCountries('countries-wrapper');
+    
     // Mount footer at the bottom (copyright only, no links)
     mountFooter();
   });
@@ -46,6 +50,8 @@ export type { NavbarConfig } from './navbarComponent';
 export { createFooter, mountFooter, unmountFooter, getFooter } from './footerComponent';
 export type { FooterConfig } from './footerComponent';
 export { mountJoke, unmountJoke, getJoke } from './jokeComponent';
+export { mountCountries, unmountCountries, getCountries } from './countriesComponent';
+export type { CountriesConfig } from './countriesComponent';
 export { 
   injectResponsiveUtilities, 
   isVisibleAtBreakpoint, 


### PR DESCRIPTION
Import mountCountries from countriesComponent and call it with
'countries-wrapper' as the target container. Component is mounted after
the joke section and before the footer to maintain correct page layout.

Build passes with TypeScript + Vite. All 39 tests passing.

